### PR TITLE
Feature/initialization helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,36 @@ module.exports = new SeedingSource({
 })
 ```
 
+### Seeding Source Initialization
+
+You must initialize your `SeedingSource` instance or manually set an
+already intialized instance of `DataSource` before you make any queries.
+
+> When you are seeding via the [CLI](#cli) command, these steps are done for you automatically at runtime.
+
+#### Initialize DataSource passed via options
+
+```javascript
+// get your seeding source instance
+const { seedingSource } = require('./seeding-source')
+
+// initialize the Data Source that was passed via options
+await seedingSource.initialize()
+```
+
+#### Manually initialize DataSource and set on SeedingSource
+
+```javascript
+const { dataSource } = require('./data-source')
+const { seedingSource } = require('./seeding-source')
+
+// initialize the Data Source manually
+await dataSource.initialize()
+
+// set on the Seeding Source
+seedingSource.dataSource = dataSource
+```
+
 ## Factory Class
 
 Factory is how we provide a way to simplify entities creation, implementing a

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -118,13 +118,6 @@ export abstract class Factory<Entity> {
    */
   async save(entities: Entity | Entity[], saveOptions?: SaveOptions): Promise<Entity | Entity[]> {
     const dataSource = this.seedingSource.dataSource
-
-    // has been initialized yet?
-    if (!dataSource.isInitialized) {
-      // no, initialize it
-      await dataSource.initialize()
-    }
-
     return dataSource.createEntityManager().save(entities, saveOptions)
   }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,6 +1,6 @@
 import { ClassConstructor, ExtractFactory, FactoryOptions, FactoryOptionsOverrides } from './types'
 
-import { SaveOptions } from 'typeorm'
+import { EntityTarget, ObjectLiteral, Repository, SaveOptions } from 'typeorm'
 import { SeedingSource } from './seeding-source'
 import { isPromiseLike } from './utils/is-promise-like.util'
 import { resolveFactory } from './utils/resolve-factory.util'
@@ -186,5 +186,12 @@ export abstract class Factory<Entity> {
    */
   factory<T>(factory: ClassConstructor<ExtractFactory<T>>): ExtractFactory<T> {
     return resolveFactory(this.seedingSource, factory, this.optionOverrides.factories)
+  }
+
+  /**
+   * Return an instance of the repository for the given entity class.
+   */
+  repository<T extends Entity & ObjectLiteral>(target: EntityTarget<T>): Repository<T> {
+    return this.seedingSource.dataSource.getRepository<T>(target)
   }
 }

--- a/src/seeder.ts
+++ b/src/seeder.ts
@@ -3,6 +3,7 @@ import { ClassConstructor, ExtractFactory, SeederInstanceOrClass, SeederOptions,
 import { SeedingSource } from './seeding-source'
 import { resolveFactory } from './utils/resolve-factory.util'
 import { resolveSeeders } from './utils/resolve-seeders.util'
+import { EntityTarget, ObjectLiteral, Repository } from 'typeorm'
 
 /**
  * Seeder
@@ -52,6 +53,13 @@ export abstract class Seeder {
    */
   factory<T>(factory: ClassConstructor<ExtractFactory<T>>): ExtractFactory<T> {
     return resolveFactory(this.seedingSource, factory, this.optionOverrides.factories)
+  }
+
+  /**
+   * Return an instance of the repository for the given entity class.
+   */
+  repository<T extends ObjectLiteral>(target: EntityTarget<T>): Repository<T> {
+    return this.seedingSource.dataSource.getRepository<T>(target)
   }
 
   /**

--- a/src/seeding-source.ts
+++ b/src/seeding-source.ts
@@ -19,16 +19,30 @@ export class SeedingSource {
    */
   constructor(private options: SeedingSourceOptions) {}
 
-  get dataSource(): DataSource {
+  async initialize() {
     if (!this._dataSource) {
       this._dataSource = resolveDataSource(this.options.dataSource)
     }
 
-    return this._dataSource
+    if (!this._dataSource.isInitialized) {
+      await this._dataSource.initialize()
+    }
+  }
+
+  get dataSource(): DataSource {
+    if (this._dataSource) {
+      return this._dataSource
+    } else {
+      throw new Error('DataSource not defined. Must be passed as an option or manually assigned.')
+    }
   }
 
   set dataSource(dataSource: DataSource) {
-    this._dataSource = dataSource
+    if (dataSource.isInitialized) {
+      this._dataSource = dataSource
+    } else {
+      throw new Error('DataSource must be initialized before manually assigning to SeedingSource.')
+    }
   }
 
   get seeders(): ClassConstructor<Seeder>[] {

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -13,7 +13,7 @@ describe(Factory, () => {
 
   beforeEach(async () => {
     seedingSource = await importSeedingSource('__fixtures__/seeding.js', __dirname)
-    await seedingSource.dataSource.initialize()
+    await seedingSource.initialize()
     userFactory = new UserFactory({ seedingSource })
     petFactory = new PetFactory({ seedingSource })
   })

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -13,8 +13,8 @@ describe(Runner, () => {
 
   beforeEach(async () => {
     seedingSource = await importSeedingSource('__fixtures__/seeding.js', __dirname)
+    await seedingSource.initialize()
     dataSource = seedingSource.dataSource
-    await dataSource.initialize()
   })
 
   afterEach(async () => {

--- a/test/seeder.test.ts
+++ b/test/seeder.test.ts
@@ -19,8 +19,8 @@ describe(Seeder, () => {
 
   beforeEach(async () => {
     seedingSource = await importSeedingSource('__fixtures__/seeding.js', __dirname)
+    await seedingSource.initialize()
     dataSource = seedingSource.dataSource
-    await dataSource.initialize()
   })
 
   afterEach(async () => {


### PR DESCRIPTION
Initial improvements for: https://github.com/conceptadev/typeorm-seeding/issues/5

There is a new initialization helper that gets called automatically when running the seeders via CLI. If you are building a programmatic seed script, you can call `SeederSource.initialize()` manually as well.

Also added some helpers for easily retrieving Repositories from inside Seeder and Factory classes.